### PR TITLE
Use node8 for the development Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/node:7
+FROM bitnami/node:8
 
 LABEL maintainer "Bitnami Team <containers@bitnami.com>"
 


### PR DESCRIPTION
The current Dockerfile used node 7 that threw a warning when installing the latest yarn:
```
warning You are using Node "7.10.1" which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: "^4.8.0 || ^5.7.0 || ^6.2.2 || ^8.0.0"
```
cc/ @sebgoa 