### PR TITLE
Use multistage builds to optimize size of the  final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,24 @@
-FROM bitnami/node:8
-
-LABEL maintainer "Bitnami Team <containers@bitnami.com>"
-
-ENV NODE_ENV=production
-
-RUN npm install yarn --global
+FROM bitnami/node:8 as builder
 
 COPY . /app
 
 WORKDIR /app
 
-RUN yarn install && \
+ENV NODE_ENV=production
+RUN npm install yarn --global && \
+    yarn install && \
     npm rebuild node-sass && \
     yarn run build
+
+FROM bitnami/node:8-prod
+
+LABEL maintainer "Bitnami Team <containers@bitnami.com>"
+
+WORKDIR /app
+
+COPY --from=builder /app /app
+
+ENV NODE_ENV=production
+RUN npm install yarn --global
 
 ENTRYPOINT ["yarn","run","start"]

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -24,6 +24,7 @@ spec:
           protocol: TCP
       - name: proxy
         image: kelseyhightower/kubectl:1.4.0
+        imagePullPolicy: IfNotPresent
         args:
         - proxy
         - "-p"

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: ui
-        image: bitnami/kubeless-ui:development
+        image: bitnami/kubeless-ui:master
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: ui
         image: bitnami/kubeless-ui:master
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 3000
           protocol: TCP


### PR DESCRIPTION
Changes:
 - Multistage Dockerfile build to optimize image size, down to 235MB from 770MB (on disk)
 - Use `bitnami/kubeless-ui:master` in the k8s.yml manifest
 - Define the `imagePullPolicy=Always` as we're using development (master) builds