### PR TITLE
use hash router to support serving from subpath

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: kubeless-ui-dev
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile-prod
     command: bash -c "yarn install && npm rebuild node-sass && yarn run dev"
     environment:
       NODE_ENV: development

--- a/src/components/AppContainer.js
+++ b/src/components/AppContainer.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 // @flow
 import React, { Component } from 'react'
-import { browserHistory, Router } from 'react-router'
+import { hashHistory, Router } from 'react-router'
 import { Provider } from 'react-redux'
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme'
@@ -48,7 +48,7 @@ export default class AppContainer extends Component {
       <Provider store={store}>
         <MuiThemeProvider muiTheme={muiTheme}>
           <div style={{ height: '100%' }}>
-            <Router history={browserHistory} children={routes} />
+            <Router history={hashHistory} children={routes} />
           </div>
         </MuiThemeProvider>
       </Provider>

--- a/src/utils/Api.js
+++ b/src/utils/Api.js
@@ -27,7 +27,7 @@ export default class Api {
       url: URL, method, json
     }
 
-    return fetch('/proxy', {
+    return fetch('proxy', {
       method: 'post',
       headers,
       body: JSON.stringify(forwardBody)


### PR DESCRIPTION
For KubeApps, we mount Kubeless UI under a /kubeless subpath so these
changes are required to make Kubeless UI work correctly under subpaths.

- also switch to relative route for calling k8s API proxy
- updates docker-compose to point to dev dockerfile (oddly named -prod)