### PR TITLE
Fix handling of pods with no labels

### DIFF
--- a/src/components/Logs/LogsContainer.js
+++ b/src/components/Logs/LogsContainer.js
@@ -23,7 +23,7 @@ import { podsSelect, podsFetchLogs, podsFetch } from 'store/pods'
 const mapStateToProps = ({ funcs, clusters, pods }) => {
   const func = funcs.selected
   const podsList = _.filter(pods.list, (p) => {
-    return p.metadata.labels['function'] === func.metadata.name
+    return p.metadata.labels && p.metadata.labels['function'] === func.metadata.name
   })
   const logs = pods.selected ? pods.logs[pods.selected.metadata.uid] : ''
   return {


### PR DESCRIPTION
Kubeless-UI currently crashes when running on a cluster with pods without labels. This change makes the function check for the existence of labels before trying to match the pod to a function. Tested on K8s 1.9 with newest Kubeless.