### PR TITLE
Adapt kubeless-ui to the new Functions API group

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -19,7 +19,7 @@ rules:
   - get
   - list
 - apiGroups:
-  - k8s.io
+  - kubeless.io
   resources:
   - functions
   verbs:

--- a/src/utils/Api.js
+++ b/src/utils/Api.js
@@ -122,7 +122,7 @@ export default class Api {
       if (url.indexOf('/api/v1') === -1 && url.indexOf('/apis/extensions') === -1) {
         let api = '/api/v1'
         if (url.indexOf('/functions') === 0) {
-          api = '/apis/k8s.io/v1'
+          api = '/apis/kubeless.io/v1beta1'
         } else if (url.indexOf('/deployments') === 0 ||
           url.indexOf('/ingresses') === 0 ||
           url.indexOf('/replicasets') === 0) {

--- a/src/utils/EntityHelper.js
+++ b/src/utils/EntityHelper.js
@@ -40,7 +40,7 @@ export default class EntityHelper {
   static functionFromParams(params: {[string]: any}) {
     return {
       kind: 'Function',
-      apiVersion: 'k8s.io/v1',
+      apiVersion: 'kubeless.io/v1beta1',
       metadata: {
         name: params.name,
         namespace: params.namespace || 'default'

--- a/tests/utils/__snapshots__/EntityHelper.spec.js.snap
+++ b/tests/utils/__snapshots__/EntityHelper.spec.js.snap
@@ -13,7 +13,7 @@ Array [
 
 exports[`(Utils) EntityHelper functionFromParams - should create Function entity from params 1`] = `
 Object {
-  "apiVersion": "k8s.io/v1",
+  "apiVersion": "kubeless.io/v1beta1",
   "kind": "Function",
   "metadata": Object {
     "name": "funcName",


### PR DESCRIPTION
Kubeless 0.4.0 severs functions uses `kubeless.io/v1beta1` instead of `k8s.io/v1`.