### PR TITLE
Adapt the UI to Kubeless 0.5

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -38,9 +38,7 @@ app.post('/proxy', function(req, res) {
   nodeFetch(url, {
     method: method,
     body: json,
-    headers: {
-      'Content-Type': 'application/json'
-    }
+    headers: req.body.headers
   }).then(function(response) {
     if (typeof response.text !== 'function') {
       return Promise.reject(new Error('Error - Not ok'))

--- a/src/components/Func/FuncDetail.js
+++ b/src/components/Func/FuncDetail.js
@@ -69,14 +69,14 @@ export default class FuncDetail extends Component {
     let requestData
     if (body) {
       try {
-        requestData = json ? JSON.parse(body) : qs.parse(body)
+        requestData = json ? JSON.parse(body) : body
       } catch (e) {
         this.setState({ errorMessage: e.message, running: false })
         return
       }
     }
     this.setState({ running: true, errorMessage: null })
-    this.props.onRun(func, requestData, cluster, method)
+    this.props.onRun(func, requestData, cluster, method, json)
   }
 
   toggleDeleteConfirmModal = () => {
@@ -103,8 +103,7 @@ export default class FuncDetail extends Component {
       spec: {
         deps: params.deps,
         handler: params.handler,
-        runtime: params.runtime,
-        type: params.type
+        runtime: params.runtime
       }
     }
     this.props.onSave(func, cluster, data)
@@ -132,8 +131,6 @@ export default class FuncDetail extends Component {
             <b>Runtime: </b>
             {func.spec.runtime}
             <br />
-            <b>Type: </b>
-            {func.spec.type}
           </p>
           <div className='actionsButtons'>
             <a className='button' onClick={this.toggleEditingModal}>

--- a/src/components/Func/FuncDetail.js
+++ b/src/components/Func/FuncDetail.js
@@ -16,7 +16,6 @@ limitations under the License.
 
 // @flow
 import React, { Component } from 'react'
-import qs from 'qs'
 import FlatButton from 'material-ui/FlatButton'
 import Dialog from 'material-ui/Dialog'
 import FuncEdit from 'components/Func/FuncEdit'

--- a/src/components/Func/FuncDetailContainer.js
+++ b/src/components/Func/FuncDetailContainer.js
@@ -26,7 +26,7 @@ const mapStateToProps = ({ funcs, clusters }) => ({
 })
 
 const mapDispatchToProps = (dispatch) => ({
-  onRun: (func, data, cluster, method) => dispatch(funcsRun(func, data, cluster, method)),
+  onRun: (func, data, cluster, method, json) => dispatch(funcsRun(func, data, cluster, method, json)),
   onSave: (func, cluster, params) => dispatch(funcsSave(func, cluster, params)),
   onDelete: (func, cluster) => dispatch(funcsDelete(func, cluster))
 })

--- a/src/components/Func/FuncParams.js
+++ b/src/components/Func/FuncParams.js
@@ -26,8 +26,7 @@ import './FuncParams.scss'
 const initialState = {
   name: '',
   handler: '',
-  runtime: '',
-  type: 'HTTP',
+  runtime: 'python2.7',
   deps: ''
 }
 export default class FuncParams extends Component {
@@ -44,7 +43,6 @@ export default class FuncParams extends Component {
         name: func.metadata.name,
         handler: func.spec.handler,
         runtime: func.spec.runtime,
-        type: func.spec.type,
         deps: func.spec.deps
       }
     } else {
@@ -78,14 +76,6 @@ export default class FuncParams extends Component {
         )
       })
     }
-    const types = [
-      <option key={1} value='HTTP'>
-        HTTP
-      </option>,
-      <option key={2} value='PubSub'>
-        PubSub
-      </option>
-    ]
     return (
       <div className='funcParams padding-v-big'>
         <div className='row'>
@@ -109,14 +99,6 @@ export default class FuncParams extends Component {
             />
           </div>
           <div className='col-3'>
-            <label htmlFor='type'>Type</label>
-            <select
-              name='type'
-              value={this.state.type}
-              onChange={e => this.handleChangeProperty('type', e.target.value)}
-            >
-              {types}
-            </select>
             <label htmlFor='runtime'>Runtime</label>
             <select
               name='runtime'

--- a/src/utils/Api.js
+++ b/src/utils/Api.js
@@ -20,13 +20,12 @@ import _ from 'lodash'
 
 export default class Api {
 
-  static apiFetch({ url, method, body, dataUrl, cluster, entity }) {
-    let { url: URL, headers } = this.updateParams({ url, method, body, dataUrl, cluster, entity })
+  static apiFetch({ url, method, body, dataUrl, cluster, entity, baseHeaders }) {
+    let { url: URL, headers } = this.updateParams({ url, method, body, dataUrl, cluster, entity, baseHeaders })
     const json = _.isEmpty(body) ? undefined : JSON.stringify(body)
     const forwardBody = {
-      url: URL, method, json
+      url: URL, method, json, headers
     }
-
     return fetch('proxy', {
       method: 'post',
       headers,
@@ -73,24 +72,24 @@ export default class Api {
     return Promise.reject(new Error(error.message))
   }
 
-  static post(url, body = {}, cluster, entity) {
-    return Api.apiFetch({ method: 'post', url, body, cluster, entity })
+  static post(url, body = {}, cluster, entity, baseHeaders) {
+    return Api.apiFetch({ method: 'post', url, body, cluster, entity, baseHeaders })
   }
 
-  static get(url, dataUrl, cluster, entity) {
-    return Api.apiFetch({ method: 'get', url, dataUrl, cluster, entity })
+  static get(url, dataUrl, cluster, entity, baseHeaders) {
+    return Api.apiFetch({ method: 'get', url, dataUrl, cluster, entity, baseHeaders })
   }
 
-  static put(url, body, cluster, entity) {
-    return Api.apiFetch({ method: 'put', url, body, cluster, entity })
+  static put(url, body, cluster, entity, baseHeaders) {
+    return Api.apiFetch({ method: 'put', url, body, cluster, entity, baseHeaders })
   }
 
-  static patch(url, body, cluster, entity) {
-    return Api.apiFetch({ method: 'patch', url, body, cluster, entity })
+  static patch(url, body, cluster, entity, baseHeaders) {
+    return Api.apiFetch({ method: 'patch', url, body, cluster, entity, baseHeaders })
   }
 
-  static delete(url, body, cluster, entity) {
-    return Api.apiFetch({ method: 'delete', url, body, cluster, entity })
+  static delete(url, body, cluster, entity, baseHeaders) {
+    return Api.apiFetch({ method: 'delete', url, body, cluster, entity, baseHeaders })
   }
 
   static getStatus(response = {}) {
@@ -111,12 +110,12 @@ export default class Api {
     return status
   }
 
-  static updateParams({ url, method, dataUrl, cluster, entity }) {
-    const headers = {
+  static updateParams({ url, method, body, dataUrl, cluster, entity, baseHeaders }) {
+    const headers = _.defaults({}, baseHeaders, {
       'X-Requested-With': 'XMLHttpRequest',
       'Accept': 'application/json',
       'Content-Type': 'application/json'
-    }
+    })
     if (cluster && url.indexOf('http') === -1) {
       let path = ''
       if (url.indexOf('/api/v1') === -1 && url.indexOf('/apis/extensions') === -1) {

--- a/src/utils/EntityHelper.js
+++ b/src/utils/EntityHelper.js
@@ -48,9 +48,7 @@ export default class EntityHelper {
         deps: params.deps || '',
         'function': params['function'] || params.defaultFunction || '',
         handler: params.handler,
-        runtime: params.runtime,
-        topic: params.topic || 'kubeless',
-        type: params.type || 'HTTP'
+        runtime: params.runtime
       }
     }
   }

--- a/src/utils/EntityHelper.js
+++ b/src/utils/EntityHelper.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 // @flow
 import _ from 'lodash'
+import crypto from 'crypto'
 
 export default class EntityHelper {
 
@@ -37,6 +38,8 @@ export default class EntityHelper {
   }
 
   static functionFromParams(params: {[string]: any}) {
+    const func = params['function'] || params.defaultFunction || ''
+    const funcSha256 = crypto.createHash('sha256').update(func).digest('hex')
     return {
       kind: 'Function',
       apiVersion: 'kubeless.io/v1beta1',
@@ -46,7 +49,8 @@ export default class EntityHelper {
       },
       spec: {
         deps: params.deps || '',
-        'function': params['function'] || params.defaultFunction || '',
+        'function': func,
+        checksum: `sha256:${funcSha256}`,
         handler: params.handler,
         runtime: params.runtime
       }

--- a/src/utils/RuntimeHelper.js
+++ b/src/utils/RuntimeHelper.js
@@ -27,23 +27,32 @@ function defaultFunction(runtime) {
     case 'nodejs':
       result = `
 module.exports = {
-  <<HANDLER>>: function(req, res) {
-     res.end("Hello World");
+  <<HANDLER>>: function(event, context) {
+     return "Hello World";
   }
 };
 `
       break
     case 'python':
       result = `
-def <<HANDLER>>():
+def <<HANDLER>>(event, context):
     return "Hello World"
 `
       break
     case 'ruby':
       result = `
-def <<HANDLER>>(request)
+def <<HANDLER>>(event, context)
   "Hello World"
 end
+`
+      break
+    case 'php':
+      result = `
+<?php
+
+function <<HANDLER>>($event, $context) {
+  return "Hello World";
+}
 `
   }
   return result

--- a/tests/utils/EntityHelper.spec.js
+++ b/tests/utils/EntityHelper.spec.js
@@ -41,8 +41,7 @@ describe('(Utils) EntityHelper', () => {
       namespace: 'kubeless',
       'function': '//code goes here',
       handler: 'funcName.foo',
-      topic: 'kubeless',
-      type: 'HTTP'
+      topic: 'kubeless'
     }
     expect(EntityHelper.functionFromParams(params)).toMatchSnapshot()
   })

--- a/tests/utils/EntityHelper.spec.js
+++ b/tests/utils/EntityHelper.spec.js
@@ -40,8 +40,7 @@ describe('(Utils) EntityHelper', () => {
       name: 'funcName',
       namespace: 'kubeless',
       'function': '//code goes here',
-      handler: 'funcName.foo',
-      topic: 'kubeless'
+      handler: 'funcName.foo'
     }
     expect(EntityHelper.functionFromParams(params)).toMatchSnapshot()
   })

--- a/tests/utils/__snapshots__/EntityHelper.spec.js.snap
+++ b/tests/utils/__snapshots__/EntityHelper.spec.js.snap
@@ -20,6 +20,7 @@ Object {
     "namespace": "kubeless",
   },
   "spec": Object {
+    "checksum": "sha256:e4032e36ebd8b1e2e7249bff8ef675a32d01a1f96ead2b6979fa9d3a2c53f371",
     "deps": "",
     "function": "//code goes here",
     "handler": "funcName.foo",

--- a/tests/utils/__snapshots__/EntityHelper.spec.js.snap
+++ b/tests/utils/__snapshots__/EntityHelper.spec.js.snap
@@ -24,8 +24,6 @@ Object {
     "function": "//code goes here",
     "handler": "funcName.foo",
     "runtime": undefined,
-    "topic": "kubeless",
-    "type": "HTTP",
   },
 }
 `;


### PR DESCRIPTION
With Kubeless 0.5 the next changes are required:
 - Functions now receive as headers the relevant data about the event source.
 - All the functions now expose an HTTP endpoint so the fields "type" and "topic" is not used anymore.
 - Function contract has changed and now PHP is supported.