### PR TITLE
Support basic authorization cookies/headers for async calls

### DIFF
--- a/src/utils/Api.js
+++ b/src/utils/Api.js
@@ -29,6 +29,7 @@ export default class Api {
     return fetch('proxy', {
       method: 'post',
       headers,
+      credentials: 'same-origin',
       body: JSON.stringify(forwardBody)
     }).then((response = {}) => {
       if (__DEV__) {


### PR DESCRIPTION
Fixes #48 

The Fetch API by default does not send cookies or the Authorization header for XHR request (although the spec is changing, fixes haven't landed in all browsers yet [[Reference](https://github.com/whatwg/fetch/pull/585)]. This means that if you try to add Basic authentication to the kubeless-ui Ingress, all the proxy calls will fail with 401 Unauthorized. This change explicitly tells the browser to send the Authorization header.

I encountered a number of other errors while trying to leverage Kubeless UI that I was planning on fixing later when I have a chance, but this was the first issue that I saw a quick fix.

Tested in Chrome 67