### PR TITLE
using kubectl image of newer version

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -91,7 +91,7 @@ spec:
         - containerPort: 3000
           protocol: TCP
       - name: proxy
-        image: kelseyhightower/kubectl:1.4.0
+        image: lachlanevenson/k8s-kubectl:v1.13.1
         imagePullPolicy: IfNotPresent
         args:
         - proxy


### PR DESCRIPTION
previous image (kelseyhightower/kubectl) is fairly old, it doesn't support directly executing kubectl in PATH, dockerfile isn't uploaded to Github either.  lachlanevenson/k8s-kubectl is more popular than kelseyhightower/kubectl, and it works well~