### PR TITLE
added namespace config to edit screen

### DIFF
--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -10,11 +10,13 @@ COPY package.json $ROOT/src/
 
 WORKDIR $ROOT/src
 
-RUN install_packages apt-transport-https
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+RUN install_packages apt-transport-https gnupg && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get purge -y gnupg && \
+    apt-get clean
 RUN install_packages yarn
 
 # build & test
 COPY . $ROOT/src/
-RUN yarn cache clean && npm cache clean && rm -rf /tmp/*
+RUN yarn cache clean && npm cache clean --force && rm -rf /tmp/*

--- a/src/components/Func/FuncDetail.js
+++ b/src/components/Func/FuncDetail.js
@@ -127,6 +127,9 @@ export default class FuncDetail extends Component {
       <div className='funcDetail'>
         <div className='functionTitle padding-big padding-t-reset'>
           <p>
+            <b>Namespace: </b>
+            {func.metadata.namespace}
+            <br />
             <b>Handler: </b>
             {func.spec.handler}
             <br />

--- a/src/components/Func/FuncDetail.js
+++ b/src/components/Func/FuncDetail.js
@@ -98,7 +98,10 @@ export default class FuncDetail extends Component {
   doneEditing = (params: any) => {
     const { func, cluster } = this.props
     const data = {
-      metadata: { name: params.name },
+      metadata: {
+        name: params.name,
+        namespace: params.namespace
+      },
       spec: {
         deps: params.deps,
         handler: params.handler,

--- a/src/components/Func/FuncParams.js
+++ b/src/components/Func/FuncParams.js
@@ -26,6 +26,7 @@ import './FuncParams.scss'
 
 const initialState = {
   name: '',
+  namespace: '',
   handler: '',
   runtime: 'python2.7',
   deps: '',
@@ -43,6 +44,7 @@ export default class FuncParams extends Component {
     if (func) {
       this.state = {
         name: func.metadata.name,
+        namespace: func.metadata.namespace,
         handler: func.spec.handler,
         runtime: func.spec.runtime,
         deps: func.spec.deps,
@@ -91,6 +93,15 @@ export default class FuncParams extends Component {
               value={this.state.name}
               disabled={!!this.props.func}
               onChange={e => this.handleChangeProperty('name', e.target.value)}
+            />
+            <label htmlFor='namespace'>Namespace</label>
+            <input
+              name='namespace'
+              id='namespace'
+              placeholder='kubeless'
+              value={this.state.namespace}
+              disabled={!!this.props.func}
+              onChange={e => this.handleChangeProperty('namespace', e.target.value)}
             />
             <label htmlFor='handler'>Handler</label>
             <input

--- a/src/utils/EntityHelper.js
+++ b/src/utils/EntityHelper.js
@@ -45,7 +45,7 @@ export default class EntityHelper {
       apiVersion: 'kubeless.io/v1beta1',
       metadata: {
         name: params.name,
-        namespace: params.namespace || 'default'
+        namespace: params.namespace || 'kubeless'
       },
       spec: {
         deps: params.deps || '',


### PR DESCRIPTION
As per https://github.com/kubeless/kubeless-ui/issues/70#issuecomment-549326336
and https://github.com/kubeless/kubeless/issues/1015#issuecomment-479570632

1. I've added a namespace option to the editor screen (src/components/Func/FuncParams.js)
2. Changed the default namespace from "default" to "kubeless" to match the kubeless cli behaviour (src/utils/EntityHelper.js)
3. Probably pointlessly fixed the Dockerfile-prod. I don't know why it was there but it didn't build. Now it does.

No additional tests added but I've built and tested the image and the results are as expected.

Please consider this PR in lieu of that fact several people have requested this feature. Thanks 